### PR TITLE
ISPN-8084 Scale templates for OpenShift Online

### DIFF
--- a/templates/infinispan-ephemeral.json
+++ b/templates/infinispan-ephemeral.json
@@ -102,7 +102,7 @@
         "name": "${APPLICATION_NAME}"
       },
       "spec": {
-        "replicas": 3,
+        "replicas": 1,
         "selector": {
           "deploymentConfig": "${APPLICATION_NAME}"
         },
@@ -188,7 +188,13 @@
                     "name": "hotrod",
                     "protocol": "TCP"
                   }
-                ]
+                ],
+                "resources": {
+                  "requests": {
+                    "cpu": "1",
+                    "memory": "500Mi"
+                  }
+                }
               }
             ],
             "terminationGracePeriodSeconds": 120,

--- a/templates/infinispan-persistent.json
+++ b/templates/infinispan-persistent.json
@@ -147,7 +147,7 @@
       },
       "spec": {
         "serviceName": "${APPLICATION_NAME}-headless",
-        "replicas": 3,
+        "replicas": 1,
         "strategy": {
           "type": "Rolling",
           "rollingParams": {
@@ -248,7 +248,13 @@
                     "name": "${APPLICATION_NAME}-data",
                     "mountPath": "/opt/jboss/infinispan-server/standalone/data"
                   }
-                ]
+                ],
+                "resources": {
+                  "requests": {
+                    "cpu": "1",
+                    "memory": "500Mi"
+                  }
+                }
               }
             ],
             "terminationGracePeriodSeconds": 120,


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-8084

Hey @tristantarrant @gustavonalle @bparees,

I'm trying to sort out good out-of-the-box limits for OpenShift Online. The idea is to get into [Burstable QoS](https://blog.openshift.com/managing-compute-resources-openshiftkubernetes/) with CPU and memory scaled to free tier (2 CPU, 1 GB of RAM). With the proposed setup it will be possible to spin up 2 infinispan nodes or 1 node and some other app. 

WDYT?

Thanks,
Sebastian